### PR TITLE
use stateBlock in CCSkybox instead of setting the OpenGL state manually

### DIFF
--- a/cocos/3d/CCSkybox.h
+++ b/cocos/3d/CCSkybox.h
@@ -28,6 +28,7 @@
 #include "base/ccTypes.h"
 #include "platform/CCPlatformMacros.h"
 #include "renderer/CCCustomCommand.h"
+#include "renderer/CCRenderState.h"
 #include "2d/CCNode.h"
 
 NS_CC_BEGIN
@@ -106,6 +107,8 @@ protected:
     GLuint      _indexBuffer;
 
     CustomCommand _customCommand;
+
+    RenderState::StateBlock* _stateBlock;
 
     TextureCube*  _texture;
 private:


### PR DESCRIPTION
use stateBlock in CCSkybox instead of setting the OpenGL state manually
